### PR TITLE
fix: 메인 페이지에서 post가 최신순으로 조회되도록 수정

### DIFF
--- a/src/main/java/EBus/EBusback/domain/mainpage/service/MainPageService.java
+++ b/src/main/java/EBus/EBusback/domain/mainpage/service/MainPageService.java
@@ -49,7 +49,7 @@ public class MainPageService {
             }
         }
 
-        List<Post> allSuggestion = postRepository.findAllByIsSuggestionOrderByCreatedDate(true);
+        List<Post> allSuggestion = postRepository.findAllByIsSuggestionOrderByCreatedDateDesc(true);
         List<MainPostResDto> suggestionList = new ArrayList<>();
         if (!(allSuggestion.isEmpty())){
             if (allSuggestion.size()<3){
@@ -64,7 +64,7 @@ public class MainPageService {
             }
         }
 
-        List<Post> allAppreciation = postRepository.findAllByIsSuggestionOrderByCreatedDate(false);
+        List<Post> allAppreciation = postRepository.findAllByIsSuggestionOrderByCreatedDateDesc(false);
         List<MainPostResDto> appreciationList = new ArrayList<>();
         if (!(allAppreciation.isEmpty())){
             if(allAppreciation.size()<3){

--- a/src/main/java/EBus/EBusback/domain/post/repository/PostRepository.java
+++ b/src/main/java/EBus/EBusback/domain/post/repository/PostRepository.java
@@ -9,5 +9,5 @@ import EBus.EBusback.domain.post.entity.Post;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
 	List<Post> findAllByIsSuggestion(Boolean isSuggestion);
-	List<Post> findAllByIsSuggestionOrderByCreatedDate(Boolean isSuggestion);
+	List<Post> findAllByIsSuggestionOrderByCreatedDateDesc(Boolean isSuggestion);
 }


### PR DESCRIPTION
 # 구현 기능
- 내림차순 설정을 빠뜨려 메인 페이지에서 post가 생성일에 대해 오름차순으로 정렬되고 상황이었어서 수정하여 최신순으로 정렬되도록 함